### PR TITLE
Fix grade loading state checks when index == 0

### DIFF
--- a/src/routes/(authed)/grades/+layout.svelte
+++ b/src/routes/(authed)/grades/+layout.svelte
@@ -19,10 +19,17 @@
 			: undefined
 	);
 
-	loadGradebooks();
+	let loadingError: unknown = $state(undefined);
+
+	loadGradebooks().catch((error) => {
+		console.error('Error loading gradebooks:', error);
+		loadingError = error;
+	});
+
+	const loadedOrError = $derived(currentGradebookState?.loaded ?? loadingError !== undefined);
 </script>
 
-<LoadingBanner show={!currentGradebookState?.loaded} loadingMsg="Loading grades..." />
+<LoadingBanner show={!loadedOrError} loadingMsg="Loading grades..." />
 
 {#if currentGradebookState?.lastRefresh !== undefined}
 	<RefreshIndicator
@@ -31,6 +38,14 @@
 		refresh={() =>
 			showGradebook(gradebooksState.overrideIndex ?? gradebooksState.activeIndex, true)}
 	/>
+{/if}
+
+{#if loadingError}
+	<Alert color="red" class="m-4">
+		An error occurred while loading grades: {loadingError instanceof Error
+			? loadingError.message
+			: String(loadingError)}
+	</Alert>
 {/if}
 
 {#if gradebooksState.overrideIndex && gradebooksState.records && gradebooksState.activeIndex && currentGradebookState?.data}

--- a/src/routes/(authed)/grades/gradebook.svelte.ts
+++ b/src/routes/(authed)/grades/gradebook.svelte.ts
@@ -18,7 +18,7 @@ interface GradebooksState {
 export const gradebooksState: GradebooksState = $state({});
 
 export const getCurrentGradebookState = (gradebooksState: GradebooksState) =>
-	gradebooksState.records && gradebooksState.activeIndex
+	gradebooksState.records && gradebooksState.activeIndex !== undefined
 		? gradebooksState.records[gradebooksState.overrideIndex ?? gradebooksState.activeIndex]
 		: undefined;
 
@@ -30,7 +30,7 @@ export const getPeriodIndex = (period: ReportPeriod, periods: ReportPeriod[]) =>
 	periods.map((period) => period._GradePeriod).findIndex((name) => name === period._GradePeriod);
 
 const saveGradebooksState = () => {
-	if (!gradebooksState.records || !gradebooksState.activeIndex)
+	if (!gradebooksState.records || gradebooksState.activeIndex === undefined)
 		throw new Error('Gradebook state not initialized before saving');
 
 	const cache: GradebooksLocalStorageCache = {


### PR DESCRIPTION
When you have a variable of type `number | undefined`, you can't check if it's defined using `!variable` because it will return `false` if the number is zero.

There was some code that was incorrectly doing this with `gradebooksState.activeIndex`, making the grades page never display even though it had loaded fine. Because `gradebooksState.activeIndex` is only zero during the first quarter of the school year, this one slipped through the cracks until now. Fixes #148.

Also adds an error alert on /grades layout if loading fails.